### PR TITLE
add css classes to item-list themer when a pager is generated bearskin-1

### DIFF
--- a/css/bear_skin.css
+++ b/css/bear_skin.css
@@ -863,16 +863,20 @@ table {
         visibility: visible;
         opacity: 1; }
 
-.item-list .pager {
-  margin: 26px 0px 26px;
-  margin: 1.625rem 0rem 1.625rem; }
-  .item-list .pager li {
-    padding: 7.8px 13px 7.8px;
-    padding: 0.4875rem 0.8125rem 0.4875rem;
-    margin: 0px 7.8px 0px;
-    margin: 0rem 0.4875rem 0rem; }
-  .item-list .pager-current {
-    border: 1px solid #555; }
+.pager .item-list .pager__list {
+  margin: 26px 0px;
+  margin: 1.625rem 0rem; }
+
+.pager .item-list .pager__item {
+  padding: 7.8px 13px;
+  padding: 0.4875rem 0.8125rem;
+  margin: 0px 7.8px;
+  margin: 0rem 0.4875rem;
+  list-style-type: none;
+  display: inline-block; }
+
+.pager .item-list .pager--current {
+  border: 1px solid #555; }
 
 #sidr-wrapper-0 {
   margin: 13px 13px 13px;

--- a/sass/02-molecules/navigation/_pagers.scss
+++ b/sass/02-molecules/navigation/_pagers.scss
@@ -1,13 +1,16 @@
-.item-list .pager {
-  @include margin(1, 0, 1, 0);
-
-  li {
-    @include padding(0.3, 0.5, 0.3, 0.5);
-    @include margin(0, 0.3, 0, 0.3);
+.pager .item-list {
+  .pager__list {
+    @include margin(1, 0);
   }
 
-  &-current {
+  .pager__item {
+    @include padding(0.3, 0.5);
+    @include margin(0, 0.3);
+    list-style-type: none;
+    display: inline-block;
+  }
+
+  .pager--current {
     border: 1px solid $off-black;
   }
-
 }


### PR DESCRIPTION
Added the same css classes for pagers that I added for Sean in another project. Kind of messy because Drupal doesn't make this simple. There is still an `<div class="item-list">` getting outputted with the pager that is totally unnecessary, but it is hardcoded in drupal :(

I also needed to change the pager css a bit in order to match the new css classes.
