### PR TITLE
Get better block template names & CSS classes

### DIFF
--- a/bear_skin.theme
+++ b/bear_skin.theme
@@ -66,6 +66,20 @@ function bear_skin_preprocess_block(&$variables) {
   // All blocks get block and block__title classes.
   $variables['attributes']['class'][] = 'block';
   $variables['title_attributes']['class'][] = 'block__title';
+  $block = \Drupal::entityTypeManager()->getStorage('block')->load($variables['elements']['#id']);
+  $region = $block->getRegion();
+  $region_class = \Drupal\Component\Utility\Html::getClass($region);
+  $module = $block->getPlugin()->getPluginId();
+  $module = str_replace('block', '', $module);
+  $module_class = \Drupal\Component\Utility\Html::getClass($module);
+
+  // All blocks get block and block__title classes.
+  $variables['attributes']['class'][] = 'block-' . $module_class;
+  $variables['attributes']['class'][] = 'block-' . $region_class;
+  $variables['attributes']['class'][] = 'block-' . $module_class . '-' . $region_class;
+  $variables['title_attributes']['class'][] = 'block-' . $module_class . '__title';
+  $variables['title_attributes']['class'][] = 'block-' . $region_class . '__title';
+  $variables['title_attributes']['class'][] = 'block-' . $module_class . '-' . $region_class . '__title';
 
   // plugin_id => class
   $map = array(
@@ -93,6 +107,32 @@ function bear_skin_preprocess_block(&$variables) {
     // Menu blocks, including main navigation.
     $variables['attributes']['class'][] = 'nav';
     $variables['attributes']['class'][] = 'nav--' . substr($variables['plugin_id'], 18);
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_block_alter().
+ */
+function bear_skin_theme_suggestions_block_alter(array &$suggestions, array $variables, $hook) {
+  $element = $variables['elements'];
+
+  if (!empty($element['content']['#block_content'])) {
+    $block_bundle = $element['content']['#block_content']->bundle();
+    $suggestions_name = 'block__block_content__' . $block_bundle;
+    array_splice($suggestions, -2, 0, $suggestions_name);
+  }
+
+  $block = entity_load('block', $element['#id']);
+  if (!empty($block) && !empty($region = $block->get('region'))) {
+    $suggestions_name = 'block__block_content__' . $region;
+    array_splice($suggestions, -2, 0, $suggestions_name);
+
+    $settings = $block->get('settings');
+    if (!empty($settings)) {
+      $suggestions_name = 'block__block_content__' . $settings['provider'];
+      array_splice($suggestions, -2, 0, $suggestions_name);
+      array_splice($suggestions, -2, 0, 'block__' . $region . '__' . $settings['provider']);
+    }
   }
 }
 

--- a/components/_patterns/02-molecules/blocks/block/block.json
+++ b/components/_patterns/02-molecules/blocks/block/block.json
@@ -18,6 +18,7 @@
       ]
     }
   },
+  "label_display": true,
   "content_element": "div",
   "content_attributes": {
     "Attribute()": {

--- a/components/_patterns/02-molecules/blocks/block/block.twig
+++ b/components/_patterns/02-molecules/blocks/block/block.twig
@@ -3,14 +3,14 @@
     <{{ element ?: "div" }}{{ attributes.addClass(classes) }}>
   {% endif %}
 
+  {{ title_prefix }}
   {% if display_title != false  %}
-    {{ title_prefix }}
     {% if label %}
       {% set title_classes = title_classes ?: "block__content" %}
       <{{ label_element ?: "h2" }}{{ title_attributes.addClass(title_classes) }}>{{ label }}</{{ label_element ?: "h2" }}>
     {% endif %}
-    {{ title_suffix }}
   {% endif %}
+  {{ title_suffix }}
 
     {% block content %}
       {{ content }}

--- a/components/_patterns/02-molecules/blocks/block/block.twig
+++ b/components/_patterns/02-molecules/blocks/block/block.twig
@@ -1,23 +1,18 @@
-{% if content %}
-  {% if element is not empty %}
-    <{{ element ?: "div" }}{{ attributes.addClass(classes) }}>
-  {% endif %}
+{% if element is not empty %}
+  <{{ element ?: "div" }}{{ attributes.addClass(classes) }}>
+{% endif %}
 
-  {{ title_prefix }}
-  {% if display_title != false  %}
-    {% if label %}
-      {% set title_classes = title_classes ?: "block__content" %}
-      <{{ label_element ?: "h2" }}{{ title_attributes.addClass(title_classes) }}>{{ label }}</{{ label_element ?: "h2" }}>
-    {% endif %}
-  {% endif %}
-  {{ title_suffix }}
+{{ title_prefix }}
+{% if label_display %}
+  {% set title_classes = title_classes ?: "block__title" %}
+  <{{ label_element ?: "h2" }}{{ title_attributes.addClass(title_classes) }}>{{ label }}</{{ label_element ?: "h2" }}>
+{% endif %}
+{{ title_suffix }}
 
-    {% block content %}
-      {{ content }}
-    {% endblock %}
+{% block content %}
+  {{ content }}
+{% endblock %}
 
-    {% if element is not empty %}
-      </{{ element ?: "div" }}>
-    {% endif %}
-
+{% if element is not empty %}
+  </{{ element ?: "div" }}>
 {% endif %}

--- a/templates/02-molecules/block.html.twig
+++ b/templates/02-molecules/block.html.twig
@@ -45,6 +45,7 @@ set title_classes = [
         "element": "article",
         "label_element": "h2",
         "label": label,
+        "label_display": label_display,
         "title_prefix": title_prefix,
         "title_suffix": title_suffix
     }

--- a/templates/02-molecules/block.html.twig
+++ b/templates/02-molecules/block.html.twig
@@ -42,7 +42,7 @@ set title_classes = [
 
 {% embed "@molecules/blocks/block/block.twig"
     with {
-        "element": "",
+        "element": "article",
         "label_element": "h2",
         "label": label,
         "title_prefix": title_prefix,


### PR DESCRIPTION
The main point of this PR is to get better block template names available. I wanted to have the option to have a template file for every custom block type. Also, we may want to style and layout a block differently for different regions. 

You should now have template suggestions for combinations of 1) the block type & 2) the block's region.

![screenshot 2017-05-10 15 51 06](https://cloud.githubusercontent.com/assets/851788/25918947/22bd44fe-359b-11e7-91da-482f8bcfe0e3.png)
![screenshot 2017-05-10 16 09 40](https://cloud.githubusercontent.com/assets/851788/25918948/22bd50b6-359b-11e7-9678-c25e6bf9a9ce.png)
![screenshot 2017-05-10 16 09 51](https://cloud.githubusercontent.com/assets/851788/25918949/22bdb1d2-359b-11e7-890a-f4e1992eada9.png)

